### PR TITLE
test: upgrade molecule-hetznercloud to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install ansible and molecule
-        run: pip3 install ansible jmespath 'molecule>=6.0,<7.0' 'https://github.com/ansible-community/molecule-hetznercloud/archive/main.zip'
+        run: pip3 install ansible jmespath 'molecule>=6.0,<7.0' 'molecule-hetznercloud>=2.0,<3.0'
 
       - uses: hetznercloud/tps-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install ansible and molecule
-        run: pip3 install ansible jmespath 'molecule>=6.0,<7.0' 'molecule-hetznercloud>=2.0,<3.0'
+        run: pip3 install ansible jmespath 'molecule>=6.0,<7.0' 'https://github.com/ansible-community/molecule-hetznercloud/archive/main.zip'
 
       - uses: hetznercloud/tps-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install yamllint
         run: pip3 install ansible-lint yamllint jmespath
@@ -29,7 +29,7 @@ jobs:
     name: Molecule
     strategy:
       matrix:
-        job: [ default, mirror-merge ]
+        job: [default, mirror-merge]
 
     permissions:
       # Required for hetznercloud/tps-action
@@ -43,10 +43,10 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install ansible and molecule
-        run: pip3 install ansible "ansible-compat<4" molecule-hetznercloud jmespath
+        run: pip3 install ansible jmespath 'molecule>=6.0,<7.0' 'molecule-hetznercloud>=2.0,<3.0'
 
       - uses: hetznercloud/tps-action@main
         with:
@@ -56,5 +56,5 @@ jobs:
         run: |
           molecule test -s ${{ matrix.job }}
         env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,17 +6,17 @@ dependency:
     role-file: molecule/requirements.yml
 
 driver:
-  name: hetznercloud
+  name: molecule_hetznercloud
 
 platforms:
-  - name: 'role-aptly-server-jammy-1'
-    server_type: 'cpx11'
-    image: 'ubuntu-22.04'
-    location: 'fsn1'
-  - name: 'role-aptly-server-bookworm-1'
-    server_type: 'cpx11'
-    image: 'debian-12'
-    location: 'fsn1'
+  - name: aptly-jammy-1
+    server_type: cpx11
+    image: ubuntu-22.04
+    location: fsn1
+  - name: aptly-bookworm-1
+    server_type: cpx11
+    image: debian-12
+    location: fsn1
 
 provisioner:
   name: ansible

--- a/molecule/mirror-merge/molecule.yml
+++ b/molecule/mirror-merge/molecule.yml
@@ -6,17 +6,17 @@ dependency:
     role-file: molecule/requirements.yml
 
 driver:
-  name: hetznercloud
+  name: molecule_hetznercloud
 
 platforms:
-  - name: 'role-aptly-server-jammy-mirror-merge-1'
-    server_type: 'cpx11'
-    image: 'ubuntu-22.04'
-    location: 'fsn1'
-  - name: 'role-aptly-server-bookworm-mirror-merge-1'
-    server_type: 'cpx11'
-    image: 'debian-12'
-    location: 'fsn1'
+  - name: aptly-jammy-1
+    server_type: cpx11
+    image: ubuntu-22.04
+    location: fsn1
+  - name: aptly-bookworm-1
+    server_type: cpx11
+    image: debian-12
+    location: fsn1
 
 provisioner:
   name: ansible


### PR DESCRIPTION
This PR will help me iron out any bug present in the rewrite of the molecule driver.

- upgrade molecule-hetznercloud to v2
  - the driver name was renamed to molecule_hetznercloud
  - each resource (servers, volumes, networks) are name spaced per role/scenario, so you may reuse instance names across scenarios
- upgrade molecule to v6 (you may pin the version to v5 if needed)


