### PR TITLE
mirror: use curl instead of ansible.builtin.url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# For next release
+  * **jonas.keidel**
+    * mirror: use curl instead of ansible.builtin.url
+      
+      Some keys are only available as binary and the echo lookup pipe does not
+      work properly. Use curl instead.
+
+*Not released yet*
+
 # Patch Release v1.0.1 (2023-12-18)
   * **Tom Siewert**
     * tasks: add missing tag for repository tasks

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,4 +25,5 @@
       - bzip2
       - gnupg2
       - zstd
+      - curl
     state: present

--- a/tasks/mirror/gpg.yml
+++ b/tasks/mirror/gpg.yml
@@ -30,7 +30,7 @@
   tags: [ aptly-mirror-gpg ]
   ansible.builtin.shell: |
     set -o pipefail
-    echo "{{ lookup('ansible.builtin.url', item.url, split_lines=false) }}" |
+    curl -sL '{{ item.url }}' |
     {{ aptly__config.gpgProvider }} \
     --no-default-keyring --keyring {{ aptly__user_home_directory }}/.gnupg/trustedkeys.gpg \
     --batch --pinentry-mode loopback --import


### PR DESCRIPTION
Some keys are only available as binary and the echo lookup pipe does not work properly. Use curl instead.