### PR TITLE
repository: add missing publish_prefix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# For next release
+  * **Tan Siewert**
+    * repository: add missing publish_prefix option
+
+*Not released yet*
+
 # Patch Release v1.0.2 (2025-01-13)
   * **jonas.keidel**
     * mirror: use curl instead of ansible.builtin.url

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ aptly__repositories:
     architectures:
       - amd64
       - arm64
+  - name: hetzner-ceph-jammy
+    distribution: jammy
+    label: cloud_platform
+    publish_prefix: hetzner-ceph
+    state: present
+    components:
+      - main
+      - experimental
+    architectures:
+      - amd64
+      - arm64
 ```
 
 ## Example playbook

--- a/tasks/repository/main.yml
+++ b/tasks/repository/main.yml
@@ -10,8 +10,10 @@
         aptly repo create -distribution="{{ aptly__repository.distribution }}" -component="{{ item }}" \
         -architectures="{{ aptly__repository.architectures | join(',') }}" \
         {{ aptly__repository.name }}-{{ item }}
+      vars:
+        create_dir: "{{ aptly__config.rootDir }}/public/{{ (aptly__repository.publish_prefix | default('')) + '/' }}dists"
       args:
-        creates: "{{ aptly__config.rootDir }}/public/dists/{{ aptly__repository.distribution }}/{{ item }}"
+        creates: "{{ create_dir }}/{{ aptly__repository.distribution }}/{{ item }}"
         executable: /bin/bash
       loop: "{{ aptly__repository.components | flatten(levels=1) }}"
       register: reg_aptly_repo_creation
@@ -23,7 +25,8 @@
         -component="{{ aptly__repository.components | join(',') }}" \
         {% if aptly__repository.origin is defined and aptly__repository.origin | length %}-origin="{{ aptly__repository.origin }}"{% endif %} \
         {% if aptly__repository.label is defined and aptly__repository.label | length %}-label="{{ aptly__repository.label }}"{% endif %} \
-        {{ [aptly__repository.name + '-'] | product(aptly__repository.components) | map('join') | list | join(' ') }}
+        {{ [aptly__repository.name + '-'] | product(aptly__repository.components) | map('join') | list | join(' ') }} \
+        {{ aptly__repository.publish_prefix | default('') }}
       args:
         creates: "{{ aptly__config.rootDir }}/public/dists/{{ aptly__repository.distribution }}/Release"
         executable: /bin/bash


### PR DESCRIPTION
Repositories can be published with a different prefix in order to prevent de-deuplication of packages only on the root level. The functionality was implemented for the `absent` state, but not for `present`.

This commit will add the missing pieces.

Tested: Create new repositories with `publish_prefix` being set and
        checked that the publish is correct.